### PR TITLE
fix: set image version from Dockerfile arg

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Parse version
+        id: version
+        run: echo "VERSION=$(awk -F= '/^ARG SQLCMD_VERSION/ {print $2}' Dockerfile)" >> $GITHUB_OUTPUT
+
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
@@ -40,6 +44,9 @@ jobs:
           images: |
             ${{ github.repository }}
             ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.VERSION }}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
This pull request updates the Docker workflow configuration in the `.github/workflows/docker.yaml` file to enhance the versioning and tagging process.

Enhancements to Docker workflow:

* Added a step to parse the version from the `Dockerfile` and store it in the GitHub Actions output. (`.github/workflows/docker.yaml`)
* Updated the image tagging process to include the parsed version and the `latest` tag if it is the default branch. (`.github/workflows/docker.yaml`)