### PR TITLE
chore: build pre-release versions of go-sqlcmd also

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,5 +13,11 @@
       "fileMatch": ["^Dockerfile$"],
       "matchStrings": ["ARG SQLCMD_VERSION=(?<currentValue>.+?)\\s"]
     }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["microsoft/go-sqlcmd"],
+      "ignoreUnstable": false
+    }
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=${BUILDPLATFORM} alpine:3 AS tools
-ARG SQLCMD_VERSION=v1.8.0
+ARG SQLCMD_VERSION=v1.8.1
 ARG TARGETARCH
 RUN apk add --update-cache --no-cache curl jq xz && \
   curl -sSL https://github.com/microsoft/go-sqlcmd/releases/download/${SQLCMD_VERSION}/sqlcmd-linux-${TARGETARCH}.tar.bz2 \


### PR DESCRIPTION
- **renovate: include pre-release versions of go-sqlcmd**
- **Bump go-sqlcmd to v1.8.1**
